### PR TITLE
Enable alpha-blending modes for GuiImage

### DIFF
--- a/include/gui-sdl/gui/GuiImage.h
+++ b/include/gui-sdl/gui/GuiImage.h
@@ -51,5 +51,5 @@ private:
     SDL_Color color = {0, 0, 0, 0};
 
 protected:
-    SDL_BlendMode blendMode;
+    SDL_BlendMode blendMode = SDL_BLENDMODE_NONE;
 };

--- a/include/gui-sdl/gui/GuiImage.h
+++ b/include/gui-sdl/gui/GuiImage.h
@@ -41,10 +41,15 @@ public:
 
     void setTexture(GuiTextureData *tex);
 
+    int setBlendMode(SDL_BlendMode blendMode);
+
 private:
     GuiTextureData *texture = nullptr;
     bool freeTextureData = false;
 
     // Color of the rect that's drawn if the picture has no texture.
     SDL_Color color = {0, 0, 0, 0};
+
+protected:
+    SDL_BlendMode blendMode;
 };

--- a/include/gui-sdl/gui/GuiTextureData.h
+++ b/include/gui-sdl/gui/GuiTextureData.h
@@ -37,5 +37,5 @@ protected:
     SDL_Texture *texture = nullptr;
     int32_t width = 0;
     int32_t height = 0;
-    SDL_BlendMode blendMode;
+    SDL_BlendMode blendMode = SDL_BLENDMODE_NONE;
 };

--- a/source/gui/GuiImage.cpp
+++ b/source/gui/GuiImage.cpp
@@ -47,10 +47,23 @@ void GuiImage::draw(Renderer *renderer) {
     if (texture) {
         texture->draw(renderer, rect, getAngle());
     } else {
+        // copy the texture to the rendering context
+        SDL_BlendMode mode;
+        SDL_GetRenderDrawBlendMode(renderer->getRenderer(), &mode);
+
+        // adjust blend mode
+        if(blendMode != mode){
+            SDL_SetRenderDrawBlendMode(renderer->getRenderer(), blendMode);
+        }
+
         SDL_SetRenderDrawColor(renderer->getRenderer(), color.r, color.g, color.b, color.a);
         SDL_RenderFillRect(renderer->getRenderer(), &rect);
         if(getAngle() != 0.0f){
             LG_Log("Drawing a rotated rect is not supported yet");
+        }
+        
+        if(blendMode != mode){
+            SDL_SetRenderDrawBlendMode(renderer->getRenderer(), mode);
         }
     }
 }
@@ -63,4 +76,9 @@ void GuiImage::setTexture(GuiTextureData *tex) {
         this->texture = tex;
         this->setSize(tex->getWidth(), tex->getHeight());
     }
+}
+
+int GuiImage::setBlendMode(SDL_BlendMode blendMode) {
+    this->blendMode = blendMode;
+    return this->texture ? this->texture->setBlendMode(blendMode) : 0;
 }


### PR DESCRIPTION
This also sets a default blending mode for GuiTextureData.