### PR TITLE
Add GuiImage::setScaleQuality

### DIFF
--- a/include/gui-sdl/gui/GuiImage.h
+++ b/include/gui-sdl/gui/GuiImage.h
@@ -20,6 +20,12 @@
 #include <gui/GuiElement.h>
 #include <gui/GuiTextureData.h>
 
+enum {
+    SCALE_NEAREST = 0,
+    SCALE_LINEAR =  1,
+    SCALE_BEST =    2,
+};
+
 //!Display, manage, and manipulate images in the GUI
 class GuiImage : public GuiElement {
 public:
@@ -43,6 +49,8 @@ public:
 
     int setBlendMode(SDL_BlendMode blendMode);
 
+    void setScaleQuality(int quality);
+
 private:
     GuiTextureData *texture = nullptr;
     bool freeTextureData = false;
@@ -52,4 +60,6 @@ private:
 
 protected:
     SDL_BlendMode blendMode = SDL_BLENDMODE_NONE;
+    int quality = SCALE_NEAREST;
+
 };

--- a/source/gui/GuiImage.cpp
+++ b/source/gui/GuiImage.cpp
@@ -44,6 +44,14 @@ void GuiImage::draw(Renderer *renderer) {
     rect.w = (int) (getScaleX() * getWidth());
     rect.h = (int) (getScaleY() * getHeight());
 
+    const char *origQuality = SDL_GetHint(SDL_HINT_RENDER_SCALE_QUALITY);
+    if(!origQuality)
+            origQuality = "nearest";
+
+    char quality[16];
+    snprintf(quality, 16, "%d", this->quality);
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
+
     if (texture) {
         texture->draw(renderer, rect, getAngle());
     } else {
@@ -66,6 +74,8 @@ void GuiImage::draw(Renderer *renderer) {
             SDL_SetRenderDrawBlendMode(renderer->getRenderer(), mode);
         }
     }
+
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, origQuality);
 }
 
 void GuiImage::setTexture(GuiTextureData *tex) {
@@ -81,4 +91,10 @@ void GuiImage::setTexture(GuiTextureData *tex) {
 int GuiImage::setBlendMode(SDL_BlendMode blendMode) {
     this->blendMode = blendMode;
     return this->texture ? this->texture->setBlendMode(blendMode) : 0;
+}
+
+void GuiImage::setScaleQuality(int quality)
+{
+    if(quality > -1 && quality < 3)
+        this->quality = quality;
 }


### PR DESCRIPTION
This allows to use linear and antisoptric scaling algos beside the default of nearest-neighbour. See https://wiki.libsdl.org/SDL_HINT_RENDER_SCALE_QUALITY for details.

The reason to choose to implement this in GuiImage instead of GuiImageTexture is that I hope we'll get multi-color GuiImages some day where this scaling will be helpfull (i.e. make 2x2px image which 4 different colors and scale it up to the multi-color image wanted).
Also source/gui/video/SDL_FontCache.cpp sets the scaling algorithm for texture fonts and we don't want to conflict with that.