### PR TITLE
GuiSound: Add workaround for slow SDL file loading.

### DIFF
--- a/include/gui-sdl/gui/GuiSound.h
+++ b/include/gui-sdl/gui/GuiSound.h
@@ -16,6 +16,7 @@
  ****************************************************************************/
 #pragma once
 
+#include <cstdio>
 #include <gui/GuiElement.h>
 #include <SDL2/SDL_mixer.h>
 
@@ -34,6 +35,9 @@ public:
 
     //!Load a file and replace the old one
     bool Load(const char *filepath);
+
+    //!Load a buffer and replace the old one
+    bool LoadBuffer(void *buffer, uint32_t size, bool freeSrc = false);
 
     //!Start sound playback
     void Play();
@@ -61,7 +65,10 @@ public:
     //!\param l Loop (true to loop)
     void SetLoop(bool l);
 
+private:
     Mix_Chunk *music = nullptr;
     int32_t loops = 0;
     int32_t playedOn = -1;
+
+    void Cleanup();
 };


### PR DESCRIPTION
This reduces the loading time from 6 to 2 seconds for a mp3 file. Quarky is aware of this loaing issue but here's a workaround untill it has been resolved.